### PR TITLE
Add support to remove PR that have migrated to a different machine.

### DIFF
--- a/scripts/clean-old-builds.sh
+++ b/scripts/clean-old-builds.sh
@@ -38,7 +38,10 @@ if [ "$#" -gt 0 ]; then
     
     MAX_DAYS_SINCE_MODIFIED_SHORT=1
     max_sec_since_modified_short=$(( 3600 * 24 * $MAX_DAYS_SINCE_MODIFIED_SHORT ))
-    
+
+    MAX_DAYS_SINCE_MODIFIED_SHORTEST=0.16
+    max_sec_since_modified_short=$(( 3600 * 24 * $MAX_DAYS_SINCE_MODIFIED_SHORTEST ))
+
     MAX_DAYS_SINCE_MODIFIED="$MAX_DAYS_SINCE_MODIFIED_LONG"
     max_sec_since_modified="$max_sec_since_modified_long"
 else
@@ -75,6 +78,14 @@ for build_dir in "$@"; do
                 rm -rf "$dir"
                 continue
             fi
+
+            # check if the PR has migrated on a new machine
+            is_duplicated_build_on_other_machine="false"
+            pr_last_built_machine="$(jenkins-get-last-node-for-pr "$pr_id" 'CI_CONFIG=$CI_CONFIG,CI_PLUGINS=$CI_PLUGINS,CI_TYPE=$CI_TYPE')"
+            if [[ "pr_last_built_machine" == "$NODE_NAME" ]]; then
+                echo "    PR $pr_id is also on node: '$pr_last_built_machine'"
+                is_duplicated_build_on_other_machine="true"                
+            fi
         fi
 
         if [[ "$build_dir/" == *"/launcher/"* ]]; then
@@ -97,8 +108,12 @@ for build_dir in "$@"; do
             MAX_DAYS_SINCE_MODIFIED="$MAX_DAYS_SINCE_MODIFIED_LONG"
             max_sec_since_modified="$max_sec_since_modified_long"
             if [[ "$build_dir/" != *"/sofa-framework/"* ]]; then
-                MAX_DAYS_SINCE_MODIFIED="$MAX_DAYS_SINCE_MODIFIED_SHORT"
-                max_sec_since_modified="$max_sec_since_modified_short"
+                MAX_DAYS_SINCE_MODIFIED="$MAX_DAYS_SINCE_MODIFIED_SHORTEST"
+                max_sec_since_modified="$max_sec_since_modified_shortest"
+            fi
+            if [[ "$is_duplicated_build_on_other_machine" == "true" ]]; then
+                MAX_DAYS_SINCE_MODIFIED="$MAX_DAYS_SINCE_MODIFIED_SHORTEST"
+                max_sec_since_modified="$max_sec_since_modified_shortest"
             fi
 
             all_configs_removed="true"

--- a/scripts/jenkins.sh
+++ b/scripts/jenkins.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -o errexit # Exit on error
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. "$SCRIPT_DIR"/utils.sh
+. "$SCRIPT_DIR"/dashboard.sh # needed for dashboard-config-string()
+
+# usage: 
+#   jenkins-get-last-node-for-pr "PR-1735" "CI_CONFIG=$CI_CONFIG,CI_PLUGINS=$CI_PLUGINS,CI_TYPE=$CI_TYPE"
+jenkins-get-last-node-for-pr() 
+{
+    local pr_id="$1"
+    local ci_config="$2"
+    response="$(curl --silent "https://ci.inria.fr/sofa-ci-dev/job/sofa-framework/job/$pr_id/$ci_config/lastBuild/api/json?pretty=true")"
+    
+    if [ -n "$response" ]; then
+        last_built_on_machine="$( echo "$response" | $python_exe -c "import sys; import json; print(json.load(sys.stdin)['builtOn'])")"
+        echo ${last_built_on_machine}
+    else
+        echo "undefine"
+    fi
+}
+
+


### PR DESCRIPTION
Add a function to get what was the latests ci node that execute the PR.
With this function it is now possible to detect that the job is not active on a different node and take decision based on that. 
Eg: 
- if running in the batch clean-node job this case could be used to reduce to either SORT duration or SHORTEST (4 hours).
- if running the clean-node script before a pr if there is not enough space to rank among the PR which one is oldest and/or duplicated
 
That's said, it is of course a better idea to reduce the amount job's jittering on nodes.