### PR TITLE
Remove MeshSTEPLoader from plugin_list.conf.default

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -366,7 +366,7 @@ if in-array "run-unit-tests" "$BUILD_OPTIONS" || in-array "run-scene-tests" "$BU
     github_message="${github_message} FIXME:"
 fi
 
-# Remove SofaCUDA and SofaPython from plugin_list.conf.default
+# Remove SofaCUDA, SofaPython and MeshSTEPLoader from plugin_list.conf.default
 echo "Removing SofaCUDA and SofaPython from plugin_list.conf.default"
 if vm-is-windows; then
     plugin_conf="$BUILD_DIR/bin/plugin_list.conf.default"
@@ -375,6 +375,7 @@ else
 fi
 grep -v "SofaCUDA " "$plugin_conf" > "${plugin_conf}.tmp" && mv "${plugin_conf}.tmp" "$plugin_conf"
 grep -v "SofaPython " "$plugin_conf" > "${plugin_conf}.tmp" && mv "${plugin_conf}.tmp" "$plugin_conf"
+grep -v "MeshSTEPLoader " "$plugin_conf" > "${plugin_conf}.tmp" && mv "${plugin_conf}.tmp" "$plugin_conf"
 
 time_millisec_postbuild_end="$(time-millisec)"
 time_sec_postbuild="$(time-elapsed-sec $time_millisec_postbuild_begin $time_millisec_postbuild_end)"


### PR DESCRIPTION
On Linux I get continuous a error when starting runSofa saying:
``` batch
[ERROR]   [PluginManager] Plugin loading failed (/data/Softwares/Releases/SOFA_v23.06.00_Linux/lib/libMeshSTEPLoader.so): libTKBRep.so.11: cannot open shared object file: No such file or directory
```

Not preventing (in my case) to run SOFA, but it disturbs users (see https://github.com/sofa-framework/sofa/discussions/4090)
This should fix it