### PR TITLE
[Regression tests] FIX windows strange getenv behavior

### DIFF
--- a/scripts/unit-tests.sh
+++ b/scripts/unit-tests.sh
@@ -21,6 +21,9 @@ if [ "$#" -ge 3 ]; then
     command="$1"
     build_dir="$(cd $2 && pwd)"
     src_dir="$(cd $3 && pwd)"
+    if vm-is-windows; then
+        src_dir="$(cd $3 && pwd -W)"
+    fi
     test_type="unit-tests"
     if [ -n "$4" ]; then
         test_type="regression-tests"


### PR DESCRIPTION
Ok, this should be the last fix. I am sorry, this shouldn't have taken so many attempts. 

The script was running correctly on my VM because I ran `unit-tests.sh` with relative paths. When I used exactly the path used by the `main.sh` script used by Jenkins, the environment variable `REGRESSION_SCENES_DIR` (line 51) was constructed with unix-like path (`/j/..../src`) instead of Windows style (`J:/..../src`). But one strange thing is that, when fetching this environment variable in the c++ code using `getenv` the first part of `REGRESSION_SCENES_DIR` was transformed in Windows style and not the second part, looking like that : (`J:/..../src/examples|/j/..../src/applications/plugins`) which is unsettling, because when echoing this environment variable in the bash script it is only unix-like path. I couldn't find anything on that behavior so maybe it is something I don't get... 

So it was working until now because the only path given was corrected thanks to a strange behavior. Now it is fixed and should behave normally. 

Two great lessons where learned today : no shortcuts when using bash and environment variables and never trust windows.