### PR TITLE
fetch and configure CSparseSolvers plugin

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -396,6 +396,7 @@ elif in-array "build-scope-full" "$BUILD_OPTIONS"; then
     add-cmake-option "-DPLUGIN_STLIB=ON -DSOFA_FETCH_STLIB=ON"
     add-cmake-option "-DPLUGIN_SOFTROBOTS=ON -DSOFA_FETCH_SOFTROBOTS=ON"
     add-cmake-option "-DPLUGIN_SHAPEMATCHINGPLUGIN=ON -DSOFA_FETCH_SHAPEMATCHINGPLUGIN=ON"
+    add-cmake-option "-DPLUGIN_CSPARSESOLVERS=ON -DSOFA_FETCH_CSPARSESOLVERS=ON"
     if [[ "$VM_HAS_BULLET" == "true" ]]; then
         add-cmake-option "-DPLUGIN_BULLETCOLLISIONDETECTION=ON"
     else


### PR DESCRIPTION
Since CSparseSolvers is now fetchable (https://github.com/sofa-framework/sofa/pull/4258), the CI needs to be updated accordingly