### PR TITLE
add compilation of VolumetricRendering

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -444,6 +444,7 @@ elif in-array "build-scope-full" "$BUILD_OPTIONS"; then
     add-cmake-option "-DPLUGIN_SOFASPHFLUID=ON"
     add-cmake-option "-DPLUGIN_COLLISIONOBBCAPSULE=ON"
     add-cmake-option "-DPLUGIN_THMPGSPATIALHASHING=OFF -DSOFA_FETCH_THMPGSPATIALHASHING=ON"
+    add-cmake-option "-DPLUGIN_VOLUMETRICRENDERING=ON"
 fi
 
 # Generate binaries?


### PR DESCRIPTION
To my knowledge, VolumetricRendering plugin is not compiled on the CI, while it does not require fancy dependencies.

Note the plugin does not compile for now. It needs https://github.com/sofa-framework/sofa/pull/4395 or another PR.